### PR TITLE
polish(lxl): fix grammar and typo

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -15,11 +15,11 @@ DI-engine is a generalized Decision Intelligence engine. It supports most basic 
 such as DQN, PPO, SAC, and domain-specific algorithms like QMIX in multi-agent RL, GAIL in inverse RL, and RND in exploration problems.
 The whole supported algorithms introduction can be found in `Algorithm <./feature/algorithm_overview.html>`_.
 
-For scalability, DI-engine supports three different training pipeline:
+For scalability, DI-engine supports three different training pipelines:
 
   - ``serial``
 
-    - feature: single-machine, learner-collector loop executes sequencially
+    - feature: single-machine, learner-collector loop executes sequentially
     - usage: academic research
   - ``parallel``
 
@@ -38,11 +38,11 @@ For scalability, DI-engine supports three different training pipeline:
 Main Features
 --------------
 
-  * DI-zoo: High performance DRL algorithm zoo, algorithm support list. `Link <feature/algorithm_overview.html>`_
+  * DI-zoo: High-performance DRL algorithm zoo, algorithm support list. `Link <feature/algorithm_overview.html>`_
   * Generalized decision intelligence algorithms: DRL family, IRL family, MARL family, searching family(MCTS) and etc.
   * Customized DRL demand implementation, such as Inverse RL/RL hybrid training; Multi-buffer training; League self-play training
   * Large scale DRL training demonstration and application
-  * Various efficiency optimization module: DI-hpc, DI-store, EnvManager, DataLoader
+  * Various efficiency optimization modules: DI-hpc, DI-store, EnvManager, DataLoader
   * k8s support, DI-orchestrator k8s cluster scheduler for dynamic collectors and other services
 
 

--- a/source/installation/index.rst
+++ b/source/installation/index.rst
@@ -53,7 +53,7 @@ Also, you can install DI-engine from the source codes in github(master branch re
 
 .. tip::
 
-   If you use ``--user`` option in installation, some executable command will be installed in user path(e.g. ``~/.local/bin``), and you should ensure this path has already been added into environment variable(e.g.
+   If you use ``--user`` option in installation, some executable command will be installed in the user path(e.g. ``~/.local/bin``), and you should ensure this path has already been added into the environment variable(e.g.
    $PATH in Linux).
 
 If you want to install the extra package required by some functions in DI-engine(such as concrete env, unittest and doc), you can execute
@@ -77,7 +77,7 @@ If you complete installation with the similar output in your terminal, the insta
 
 .. note::
 
-   The whole installation procedure often lasts about 30 seconds(depends on the download speed of packages), if there are some failed packages, you can also refer to ``setup.py`` and install the specific
+   The whole installation procedure often lasts about 30 seconds(depending on the download speed of packages), if there are some failed packages, you can also refer to ``setup.py`` and install the specific
    package manually.
 
 Development Version
@@ -111,4 +111,4 @@ Besides, DI-engine also prepare the CLI tool for users, you can type the followi
 
    ding -v
 
-If the terminal return the correct information, you can use this CLI tool for the common training and evaluation, you can type ``ding -h`` for further usage
+If the terminal returns the correct information, you can use this CLI tool for the common training and evaluation, and you can type ``ding -h`` for further usage

--- a/source/intro_rl/basic.rst
+++ b/source/intro_rl/basic.rst
@@ -1,7 +1,7 @@
 Basic Concepts
 ^^^^^^^^^^^^^^^
 
-Reinforcement learning (RL) has been used to solve the interaction problem between agents and environments. The interaction process can be simply described as follows: An agent receives observation from the environment, and acts accordingly. The environment will change due to the action taken by the agent and send a reward to the agent. This process runs repeatedly and the goal of the agent is to maximise the cumulative reward (sum of (discounted) rewards) received. The objective of reinforcement learning is to enable agents to learning strategies which we call 'policy' and maximise the cumulative reward. 
+Reinforcement learning (RL) has been used to solve the interaction problem between agents and environments. The interaction process can be simply described as follows: An agent receives observation from the environment, and acts accordingly. The environment will change due to the action taken by the agent and send a reward to the agent. This process runs repeatedly and the goal of the agent is to maximize the cumulative reward (sum of (discounted) rewards) received. The objective of reinforcement learning is to enable agents to learn strategies which we call 'policy' and maximize the cumulative reward. 
 
 To have a basic understanding for reinforcement learning, we explain the following basic concepts：
 
@@ -27,9 +27,9 @@ Markov Decision Process/MDP
 
 - Markov property：State :math:`s_t` is Markov, iff :math:`P[s_{t+1}|s_t] = P[s_{t+1}|s_1, ..., s_t]` .
 - A Markov process is a memoryless random process, i.e., a sequence of random states S_1,　S_2... with the Markov process.
-- Markov process is a binary tuple :math:`(S, P)` , satisfying: :math:`S` a finite set of states, :math:`P` is a probability transition matrix. There are no rewards or actions in a Markov process. A Markov process that takes actions and rewards into account is called a MDP.
+- Markov process is a binary tuple :math:`(S, P)` , satisfying: :math:`S` a finite set of states, :math:`P` is a probability transition matrix. There are no rewards or actions in a Markov process. A Markov process that takes actions and rewards into account is called an MDP.
 - MDP is a tuple :math:`(S, A, P, R, \gamma)`， :math:`S` is a finite set of states, :math:`A` is a finite set of actions， :math:`P` is a state transition probability matrix, :math:`R` is a reward function， :math:`\gamma` is a discount factor used to calculate the accumulated rewards. Unlike the Markov process, the state transfer probability of the Markov decision process is :math:`P(s_{t+1}|s_t, a_t)` . :math:`P(s_{t+1}|s_t, a_t)` .
-- The goal of reinforcement learning is to seek an optimal policy based on a MDP.  The so-called policy :math:`\pi(a|s)` refers to the mapping of states to actions. In reinforcement learning, we only discuss Markov decision processes with finite state space.
+- The goal of reinforcement learning is to seek an optimal policy based on an MDP.  The so-called policy :math:`\pi(a|s)` refers to the mapping of states to actions. In reinforcement learning, we only discuss Markov decision processes with finite state space.
 
 Common methods for solving MDP problems:
 
@@ -38,7 +38,7 @@ Common methods for solving MDP problems:
 
    DP has the following characteristics:
 
-   - Update is based on currently existing estimates: the value estimate of a current state is updated with the value estimate of each of its subsequent states
+   - Updating is based on currently existing estimates: the value estimate of a current state is updated with the value estimate of each of its subsequent states
    - Asymptotic convergence
    - Advantages: reduced variance and faster learning
    - Disadvantages: bias dependent on the quality of the function approximation
@@ -47,7 +47,7 @@ Common methods for solving MDP problems:
 
 2. **Monte Carlo methods (MC)**  are based directly on the definition of the optimal value function and provide an unbiased estimate of the optimal value function by sampling. MC replaces the actual expected return with the sample return and solves the optimal strategy empirically only.
    
-   MC do not need an environmental model. Data simulation and sampling models can be applied to MC and MC can only evaluate a certain state of interest. In comparison with DP, MC performs better when the Markov property does not hold.
+   MC does not need an environmental model. Data simulation and sampling models can be applied to MC and MC can only evaluate a certain state of interest. In comparison with DP, MC performs better when the Markov property does not hold.
  
 
 3. **Temperal-Differnece learning (TD)**, TD error: :math:`\delta_{t} = R_{t+1} + \gamma V(S_{t+1}) - V(S_t)`
@@ -57,16 +57,16 @@ Common methods for solving MDP problems:
 
 State Spaces
 --------------------
-State :math:`s` is a global description of the environment，observation :math:`o` is a partial description of the environment. States and observations from an environment can be represented by real vectors, matrix or tensors. For example, RGB pictures are used in Atari games to represent information about the game environment, and vectors are used in MuJoCo control tasks to represent the state of an intelligent body.
+State :math:`s` is a global description of the environment，observation :math:`o` is a partial description of the environment. States and observations from an environment can be represented by real vectors, matrices or tensors. For example, RGB pictures are used in Atari games to represent information about the game environment, and vectors are used in MuJoCo control tasks to represent the state of an intelligent body.
 
 When an agent can receive all information of states in an environment :math:`s` ，we call its learning process fully observable. When an agent can only receive partial information of states in an environment :math:`o`，we call its learning process partially observable，namely, partially observable Markov decision processes (POMDP) :math:`(O, A, P, R, \gamma)`.
 
 
 Action Spaces
 ---------------------
-Different environments allow different action space. The set of all valid actions :math:`a` in an environment is generally referred to as the Action Space. The action space can be classified into a discrete action space or a continuous action space.
+Different environments allow different action spaces. The set of all valid actions :math:`a` in an environment is generally referred to as the Action Space. The action space can be classified into a discrete action space or a continuous action space.
 
-For example, in Atari games and SMAC games, the action spaces are both discrete and only a limited number of actions can be selected from each space. However, in some robot continuous control tasks such as MuJoCo, the action space is continuous and generally belong to a real-valued vector interval.
+For example, in Atari games and SMAC games, the action spaces are both discrete and only a limited number of actions can be selected from each space. However, in some robot continuous control tasks such as MuJoCo, the action space is continuous and generally belongs to a real-valued vector interval.
 
 
 Policy
@@ -74,34 +74,34 @@ Policy
 **Policy** determines actions an agent takes when facing different states. If a policy is deterministic, it is usually denoted by :math:`a_t = \mu(s_t)` .
 when a policy is stochastic，it is usually denoted by :math:`a_t ~ \pi(·｜s_t')`.
 
-In reinforcement learning，the policy gradient approach requires to learn a parametric representation of the policy (parameterized policy) by fitting a policy function with parameters. :math:`\theta` is often used as the parameters. Another approach based on value functions does not necessarily require a policy gradient function. In the following sections we describe in a more detail the approach to learning polices in reinforcement learning.
+In reinforcement learning，the policy gradient approach requires learning a parametric representation of the policy (parameterized policy) by fitting a policy function with parameters. :math:`\theta` is often used as the parameters. Another approach based on value functions does not necessarily require a policy gradient function. In the following sections, we describe in a more detailed approach to learning policies in reinforcement learning.
 
 
 Trajectory
 ---------------
-In reinforcement learning, a sample learning sequence in a MDP is called **trajectory** :math:`(s_0, a_0, ..., s_n, a_n)`. Trajectory data includes a state transition function，namely, :math:`s_{t+1} = f(s_t, a_t)` and a policy followed by the agents. Reinforcement learning contains two parts: how to use the policy to sample the trajectory data and how to use the trajectory data to update the learning target. The difference between the two components creates a difference in reinforcement learning methods.
+In reinforcement learning, a sample learning sequence in an MDP is called **trajectory** :math:`(s_0, a_0, ..., s_n, a_n)`. Trajectory data includes a state transition function，namely, :math:`s_{t+1} = f(s_t, a_t)` and a policy followed by the agents. Reinforcement learning contains two parts: how to use the policy to sample the trajectory data and how to use the trajectory data to update the learning target. The difference between the two components creates a difference in reinforcement learning methods.
 
 As the trajectory also contains information about the dynamics of the model in the environment, it is possible to use the policy data to learn information about the environment as well, which can be used to help the learning of the intelligence. \
 
-Note that the transition function can be deterministic or stochastic. In a grid world, the trainsition function is determistic, i.e., an agent is going to go to a certain state given its current state and action. On the contrary, the state function is stochastic if an agent's current state and action are given, but the agent may end up with more than one states with each probability samller than one. A stochastic state function is random in nature and cannot be determined completely by an agent. 
+Note that the transition function can be deterministic or stochastic. In a grid world, the transition function is deterministic, i.e., an agent is going to go to a certain state given its current state and action. On the contrary, the state function is stochastic if an agent's current state and action are given, but the agent may end up with more than one state with each probability smaller than one. A stochastic state function is random in nature and cannot be determined completely by an agent. 
 This case can be easily illustrated in a simple MDP environment.
 
 Return and reward
 ---------------------
-**Reward** is learning signal assigned to an agent by its surrounding environment. When the enironment changes，the reward function also changes. The reward function is determined by the current state and the action taken by the agent，and can be written as :math:`r_t = R(s_t, a_t)`
+**Reward** is a learning signal assigned to an agent by its surrounding environment. When the environment changes，the reward function also changes. The reward function is determined by the current state and the action taken by the agent，and can be written as :math:`r_t = R(s_t, a_t)`
 
-**Cumulative Reward** is the sum of the decaying returns from moment t onwards in a MDP.
+**Cumulative Reward** is the sum of the decaying returns from moment t onwards in an MDP.
 
 :math:`G_t = R_{t+1}+\gamma * R_{t+2}+{\gamma}^2 * R_{t+3}+ ...`
 
-:math:`\gamma` The discount factor reflects the ratio between the value of future rewards and that at the present moment. A value close to 0 indicates a tendency towards a 'myopic' assessment and a value close to 1 indicating a more forward-looking interest and confidence in the future. The introduction of the discount factor not only easy to express mathematically, but also avoids falling into an infinite loop and reduces the uncertainty of future benefits.
+:math:`\gamma` The discount factor reflects the ratio between the value of future rewards and that at the present moment. A value close to 0 indicates a tendency towards a 'myopic' assessment and a value close to indicates a more forward-looking interest and confidence in the future. The introduction of the discount factor is not only easy to express mathematically, but also avoids falling into an infinite loop and reduces the uncertainty of future benefits.
 
 Other difficulties in dealing with reward functions may exist in different environments, such as sparse rewards where the environment does not give feedback in every state and only acquires rewards after a period of trajectory has elapsed. Therefore, the design and processing of reward functions in reinforcement learning are important directions that have a significant impact on the effectiveness of reinforcement learning.
 
 
 RL optimization problem
 ------------------------
-In simple terms, the goal of a reinforcement learning problem is to find a policy that maximizes the expected total reward. Then, if we can calculate the return after each state by taking some action, we only need to take the action with the higher reward or the action that will lead to the states with the higher reward. Thus, the estimation of expected reward is also an optimisation direction for reinforcement learning. Another approach is to search directly over the action space. In either case, the ultimate optimisation goal is to maximise the reward.
+In simple terms, the goal of a reinforcement learning problem is to find a policy that maximizes the expected total reward. Then, if we can calculate the return after each state by taking some action, we only need to take the action with the higher reward or the action that will lead to the states with the higher reward. Thus, the estimation of expected reward is also an optimization direction for reinforcement learning. Another approach is to search directly over the action space. In either case, the ultimate optimization goal is to maximize the reward.
 
 
 
@@ -120,7 +120,7 @@ The relationship between the state-valued function and the action-valued functio
 
 :math:`V_{\pi}(s) = \sum \pi(a|s)Q_{\pi}(s,a)`
 
-We can further obtain the relationship between the optimal state value function and the optimal behavioural value function as follows.
+We can further obtain the relationship between the optimal state value function and the optimal behavioral value function as follows.
 
 :math:`V*(s)=max_a Q*(s, a)`
 
@@ -138,7 +138,7 @@ We can express the state value function and the action value function as:
 
 :math:`Q*(s, a) = E_{\pi}[R_{t+1}+\gamma * max_{a'}Q(s_{t+1},a')|s_t=s, a_t=a]`
 
-Value based reinforcement learning approach includes two steps：policy evalution and policy improvement. Reinforcement learning first estimate the value function based on the policy，then, improves the policy according to the value function. When the value function reaches the optima, the policy is considered as the optimal policy. This optimal policy is a greedy policy.
+Value based reinforcement learning approach includes two steps：policy evaluation and policy improvement. Reinforcement learning first estimate the value function based on the policy，then, improves the policy according to the value function. When the value function reaches the optima, the policy is considered as the optimal policy. This optimal policy is a greedy policy.
 
 For systems where the model is known, the value function can be obtained using DPs; For systems where the model is unknown, it can be obtained using MC or TD.
 
@@ -149,11 +149,11 @@ Policy Gradients
 ------------------------
 In some situations，a stocatic policy is better than a deterministic policy. As a result, value-based reinforcement learning cannot learn such policy and a policy-based approach to reinforcement learning is therefore proposed.
 
-Unlike value-based reinforcement learning, policy-based reinforcement learning parameterise the policy and represent it by using linear or non-linear functions to find the optimal parameters that maximise the expectation of the cumulative reward, the goal of reinforcement learning.
+Unlike value-based reinforcement learning, policy-based reinforcement learning parameterises the policy and represent it by using linear or non-linear functions to find the optimal parameters that maximize the expectation of the cumulative reward, the goal of reinforcement learning.
 
-In the value-based approach, we iteratively compute the value function and then improve the policy based on the value function, whereas in the policy search approach, we directly compute the policy iteration using **policy gradient**, i.e. we compute the policy gradient on the action, and iteratively update the policy parameter values along the gradient until the expectation of cumulative return is maximised, at which point the policy corresponding to the parameter is the optimal policy.
+In the value-based approach, we iteratively compute the value function and then improve the policy based on the value function, whereas in the policy search approach, we directly compute the policy iteration using **policy gradient**, i.e. we compute the policy gradient on the action, and iteratively update the policy parameter values along the gradient until the expectation of cumulative return is maximzed, at which point the policy corresponding to the parameter is the optimal policy.
 
-Comparing to the value-based approach, the policy gradient reinforcement learning tends to converge to a local minimum, which is not sufficient when evaluating an individual policy and has a large variance.
+Compared to the value-based approach, the policy gradient reinforcement learning tends to converge to a local minimum, which is not sufficient when evaluating an individual policy and has a large variance.
 
 For a more detailed understanding of the policy based approach, please refer to the specific algorithms in our documentation：　`Hans On
 RL <../hands_on/index.html>`__
@@ -162,7 +162,7 @@ RL <../hands_on/index.html>`__
 
 Actor Critic
 -----------------------
-**Critic**, parametrized behavioural value function; performs the value evaluation of the policy.
+**Critic**, parametrized behavioral value function; performs the value evaluation of the policy.
 
 **Actor**, parametrized policy function, performs an update of the policy function parameters using the policy gradient according to the value obtained in the Critic part.
 
@@ -172,9 +172,9 @@ More Actor Critic algorithms such as A2C, DDPG, TD3, etc. are explained in our d
 
 Model-based RL
 ----------------------
-Of the above model-free approaches, the value-based approach learns the value function (MC or TD) before updating the policy, while the policy-based approach updates the policy directly. The model-based approach focuses on the environment dynamics, where a model of the environment is learned through sampling, and then the value function/ policy is optimised based on the learned environment model.
+Of the above model-free approaches, the value-based approach learns the value function (MC or TD) before updating the policy, while the policy-based approach updates the policy directly. The model-based approach focuses on the environment dynamics, where a model of the environment is learned through sampling, and then the value function/ policy is optimized based on the learned environment model.
 
-Once the modeling of the environment has been completed, there are also two paths in the model-based approach: one is to generate some simulation trajectories from the learned model and estimate the value function from the simulation trajectories to optimise the strategy; the other is to optimise the policy directly from the learned model, which is the route the model-based approach is usually taking. Learning a model of the environment first can help us to solve the problem of sample efficiency in reinforcement learning methods.
+Once the modeling of the environment has been completed, there are also two paths in the model-based approach: one is to generate some simulation trajectories from the learned model and estimate the value function from the simulation trajectories to optimise the strategy; the other is to optimize the policy directly from the learned model, which is the route the model-based approach is usually taking. Learning a model of the environment first can help us to solve the problem of sample efficiency in reinforcement learning methods.
 
 The definition of a model can be expressed mathematically as a tuple of state transfer distributions and reward functions. 
 
@@ -182,14 +182,14 @@ The definition of a model can be expressed mathematically as a tuple of state tr
 
 The learning of a model can be extended to different algorithms depending on the model construction.
 
-Model-based policy optimisation: A classical approach is to first sample a large amount of data by some strategy, then learn a model to minimise the error, apply the learned model to planning to obtain new data, and repeat the above steps. It is by doing planning on top of the learned model that model-based improves the efficiency of the entire iteration of the reinforcement learning algorithm.
+Model-based policy optimization: A classical approach is to first sample a large amount of data by some strategy, then learn a model to minimize the error, apply the learned model to planning to obtain new data, and repeat the above steps. It is by doing planning on top of the learned model that model-based improves the efficiency of the entire iteration of the reinforcement learning algorithm.
 
 
 Q&A
 ----
 Q1: What are model-based and model-free methods，what are the differences？Which category should MC、TD、DP, etc. belong to?
  - Answer：
-   model based algorithm means that the algorithm learns the state transition process of the environment and models the environment, whereas a model free algorithm does not require the environment to be modelled.
+   model based algorithm means that the algorithm learns the state transition process of the environment and models the environment, whereas a model free algorithm does not require the environment to be modeled.
    Monte Carlo and TD algorithms are model-free because they do not require the algorithm to model a specific environment.
    Dynamic programming, on the other hand, is model-based, as the use of dynamic programming requires a complete model of the environment.
 
@@ -203,14 +203,14 @@ Q2: What do we mean by value-based， policy-based and collector-critic？ which
 Q3: What are on-policy and off-policy？
  - Answer：The on-policy algorithms are trained using the current policy. The policy used to generate sampled data is the same as the policy to be evaluated and improved. 
    Off-policy algorithm, on the other hand, can be trained using the policy from the previous process, and the policy used to generate the sampled data is different from the policy to be evaluated and improved, i.e., the data generated is "off" the trajectory of the decision series determined by the policy to be optimised.
-   On-policy and off-policy simply means how training is done, and sometimes an algorithm may even have different ways of  implementation of on-policy and off-policy.
+   On-policy and off-policy simply mean how training is done, and sometimes an algorithm may even have different ways of  implementation of on-policy and off-policy.
 
-Q4: What are online training and offline training？ How do we implement ffline training？
- - Answer： Offline training means the training uses fixed datasets as input  instead of using a collector to interact with the environment. For example, behavioural cloning is a classic offline training algorithm. We usually input batch data in a fixed dataset, hence, offline RL is also called batch RL.
+Q4: What are online training and offline training？ How do we implement offline training？
+ - Answer： Offline training means the training uses fixed datasets as input  instead of using a collector to interact with the environment. For example, behavioral cloning is a classic offline training algorithm. We usually input batch data in a fixed dataset, hence, offline RL is also called batch RL.
 
-Q5: What are expolration and expolitation？What methods do we use to balance expolration and expolitation？
+Q5: What are exploration and exploitation？What methods do we use to balance exploration and exploitation？
  - Answer：Exploration is when an agent in RL is constantly exploring different states of the environment, while exploitation is when the agent selects the most rewarding action possible for the current state.
-   There are many ways to balance exploration and exploitation. There are also different ways of implementations in different algorithms. With respect to sampling in discrete action spaces, one can follow a probability distribution or select randomly. With respect to sampling in continuous action spaces, one can follow a coutinuous distribution or add NOISE.
+   There are many ways to balance exploration and exploitation. There are also different ways of implementation in different algorithms. With respect to sampling in discrete action spaces, one can follow a probability distribution or select randomly. With respect to sampling in continuous action spaces, one can follow a continuous distribution or add NOISE.
 
-Q6: Why do we use replay buffer？ why do we neew experience replay？
- - AnswerBy using the replay buffer, we can store the experiences in the buffer and sample the experiences in the buffer during subsequent training. Experience replay is a technique that saves samples from the system's exploration of the environment and then samples them to update the model parameters.
+Q6: Why do we use replay buffer？ why do we need experience replay？
+ - Answer：By using the replay buffer, we can store the experiences in the buffer and sample the experiences in the buffer during subsequent training. Experience replay is a technique that saves samples from the system's exploration of the environment and then samples them to update the model parameters.

--- a/source/key_concept/index.rst
+++ b/source/key_concept/index.rst
@@ -68,7 +68,7 @@ For the subprocess-type env manager, DI-engine uses shared memory among differen
    If the environment is some kind of client, like SC2 and CARLA, maybe a new env manager based on python thread can be faster.
 
 .. note::
-   If there are some pre-defined neural networks in the environment using GPU, like the feature extractor VAE trained by self-supervised training before RL training, DI-engine recommends to utilize parallel executions in each subprocess rather than stack all the data in the main process and then forward this network. Moreover, it is not an elegant method, DI-engine will try to find some new flexible and general solution.
+   If there are some pre-defined neural networks in the environment using GPU, like the feature extractor VAE trained by self-supervised training before RL training, DI-engine recommends utilizing parallel executions in each subprocess rather than stack all the data in the main process and then forward this network. Moreover, it is not an elegant method, DI-engine will try to find some new flexible and general solution.
 
 Besides, for robustness in practical usage, like IPC error(broken pipe, EOF) and environment runtime error, DI-engine also provides a series of **Error Tolerance** tools, e.g.: watchdog and auto-retry.
 
@@ -89,7 +89,7 @@ prepares some simple interface methods, and combines them into 3 common modes—
    images/policy_mode.svg
 
 Learn_mode aims to policy updating, collect_mode does proper exploration and exploitation to collect training data, eval_mode evaluates policy performance clearly and fairly. And the users can customize their
-own algorithm ideas by overriding these modes or design their customized modes, such as hyperparameters annealing according to training result, select battle players in self-play training, and so on. For more details,
+own algorithm ideas by overriding these modes or design their customized modes, such as hyperparameters annealing according to training results, selecting battle players in self-play training, and so on. For more details,
 the users can refer to `Policy Overview <../feature/policy_overview.html>`_.
 
 .. note::
@@ -97,7 +97,7 @@ the users can refer to `Policy Overview <../feature/policy_overview.html>`_.
 
 Shared Model + Model Wrapper
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Neural network, often called model, is the one of most important components in the whole algorithm. For serial pipeline, the model is usually created in the public common constructor method(``__init__``) or out of policy and passed to the policy as arguments. Therefore, the model is shared among different modes for convenience. And DI-engine extends the model with more runtime function by ``Model Wrapper`` , which makes the shared model can exhibit different behaviors in different modes, such as sampling action by multinomial distribution in collect mode while :math:`argmax` in evaluating mode. Here are some concrete code examples:
+Neural network, often called model, is one of the most important components in the whole algorithm. For serial pipeline, the model is usually created in the public common constructor method(``__init__``) or out of policy and passed to the policy as arguments. Therefore, the model is shared among different modes for convenience. And DI-engine extends the model with more runtime function by ``Model Wrapper`` , which makes the shared model can exhibit different behaviors in different modes, such as sampling action by multinomial distribution in collect mode while :math:`argmax` in evaluating mode. Here are some concrete code examples:
 
 .. code:: python
 
@@ -115,11 +115,11 @@ If you want to know about the detailed information of the pre-defined model wrap
 
 Processing Function
 ^^^^^^^^^^^^^^^^^^^^^^
-In practical algorithm implementations, the users often need to many data processing operations, like stacking several samples into a batch, data transformation between torch.Tensor and np.ndarray. As for RL
-algorithms themselves, there are a great number of different styles of data pre-processing and aggregation, such as calculating N-step return and GAE(Generalized Advantage Estimation), split trajectories or unroll segments, and so on. Since then, DI-engine has provided some common processing functions, which can be called as a pure function. And the users can utilize these functions both in collect mode and in learning mode.
+In practical algorithm implementations, the users often need too many data processing operations, like stacking several samples into a batch, data transformation between torch.Tensor and np.ndarray. As for RL
+algorithms themselves, there are a great number of different styles of data pre-processing and aggregation, such as calculating N-step return and GAE(Generalized Advantage Estimation), split trajectories or unroll segments, and so on. Since then, DI-engine has provided some common processing functions, which can be called a pure function. And the users can utilize these functions both in collect mode and in learning mode.
 
 For example, where should we calculate advantages for some on-policy algorithms, such as A2C/PPO, learn mode or collect mode? The former can distribute computation to different collector nodes in distributed
-training for saving time, and the latter can usually gain better performance due to more accurate approximation, just a trade-off. For a framework, it is more wiser to offer some powerful and efficient tools rather
+training for saving time, and the latter can usually gain better performance due to more accurate approximation, just a trade-off. For a framework, it is much wiser to offer some powerful and efficient tools rather
 than restricting some fixed pipelines. The following table shows some existing processing functions and related information:
 
 
@@ -150,7 +150,7 @@ The overall design is as follows:
 .. image:: images/config.png
    :alt:
 
-As you can see from above diagram, the entire config is mainly from two parts. One is called Default Config,
+As you can see from the above diagram, the entire config is mainly from two parts. One is called Default Config,
 which is our recommended setting for policy and env, and may not change a lot. The other is called User Config,
 which users may want to specify case by case.
 
@@ -265,7 +265,7 @@ quantity and quality data for policy training (learner). And collector is only r
 these data can be used for training directly or pushed into replay buffer.
 
 There are 3 core parts for a collector——env manager, policy(collect_mode), collector controller, and these parts can be implemented in a
-single process or located in several machines. Usually, DI-engine use a multi-process env_manager and another main loop controller process with policy to construct a collector, which may be extended in the future.
+single process or located in several machines. Usually, DI-engine uses a multi-process env_manager and another main loop controller process with policy to construct a collector, which may be extended in the future.
 
 Due to different send/receive data logic, the collector now is divided into two patterns——serial and parallel, we will introduce them separately.
 
@@ -314,7 +314,7 @@ The core usage of collector is quite simple, the users just need to create a cor
 
 
 The structure and main loop of collector can be summarized as the next image, the interaction of policy and env consists of ``policy.forward``, ``env.step`` and the related support codes. Then ``policy.process_transition`` and
-``policy.get_train_sample`` contributes to process data into training samples and pack them to a list. For ``EpisodeCollector``, which is usually used in some cases that need to do special post-processing,
+``policy.get_train_sample`` contributes to processing data into training samples and packing them into a list. For ``EpisodeCollector``, which is usually used in some cases that need to do special post-processing,
 ``policy.get_train_sample`` is disabled and the users can do anything after receiving the collected data.
 
 .. image::
@@ -403,9 +403,9 @@ Based on ``NaiveReplayBuffer``, ``AdvancedReplayBuffer`` and ``EpisodeReplayBuff
 .. tip::
    By default, most policies in DI-engine adopt ``AdvancedReplayBuffer``, because we think monitor and logger are rather important in debugging and policy tuning. However, if you are sure that you do not need all the features above, you can feel free to switch to simpler and faster ``NaiveReplayBuffer``.
 
-``EpisodeReplayBuffer`` is designed for some special cases where they need a whole episode rather than separated samples. For example: In chess, go or card games, players get reward only when the game is over; In some algorithms like `Hindsight Experience Replay <https://arxiv.org/abs/1707.01495>`_, must sample out a whole episode and operate on it. Therefore, in ``EpisodeReplayBuffer``, each element is no longer a training sample, but an episode.
+``EpisodeReplayBuffer`` is designed for some special cases where they need a whole episode rather than separated samples. For example: In chess, go or card games, players get a reward only when the game is over; In some algorithms like `Hindsight Experience Replay <https://arxiv.org/abs/1707.01495>`_, must sample out a whole episode and operate on it. Therefore, in ``EpisodeReplayBuffer``, each element is no longer a training sample, but an episode.
 
-In DI-engine, we define **full data** and **meta data**. **Full data** is often a dict, with keys ``['obs', 'action', 'next_obs', 'reward', 'info']`` and some optional keys like ``['priority', 'use_count', 'collect_iter', ...]``. However, in some complex environments(Usually we run them in parallel mode), ``['obs', 'action', 'next_obs', 'reward', 'info']`` can be too big to store in memory. Therefore, we store them in file system, and only store **meta data** including ``'file_path'`` and optional keys in memory. Therefore, in parallel mode, when removing the data out of buffer, we must not only remove meta data in memory but also remove that in the file system as well.
+In DI-engine, we define **full data** and **meta data**. **Full data** is often a dict, with keys ``['obs', 'action', 'next_obs', 'reward', 'info']`` and some optional keys like ``['priority', 'use_count', 'collect_iter', ...]``. However, in some complex environments(Usually we run them in parallel mode), ``['obs', 'action', 'next_obs', 'reward', 'info']`` can be too big to store in memory. Therefore, we store them in the file system, and only store **meta data** including ``'file_path'`` and optional keys in memory. Therefore, in parallel mode, when removing the data out of buffer, we must not only remove meta data in memory but also remove that in the file system as well.
 
 If you want to know more details about the three types of replay buffers, or the remove mechanism in parallel mode, please refer to `Replay Buffer Overview <../feature/replay_buffer_overview.html>`_
 
@@ -416,11 +416,11 @@ Evaluator, another key execution component of DI-engine, is used to determine wh
 or not. Similar to collector, evaluator consists of three key components ——env manager, policy(eval_mode), evaluator
 controller.
 
-Env manager allow us to run multiple environments one by one(``base_env_manager`) or in parallel
+Env manager allows us to run multiple environments one by one(``base_env_manager`) or in parallel
 (``subprocess_env_manager``). For example, if we use subprocess env manager, we will run different environments
 in different subprocesses, which will greatly increase the efficiency of collecting episodes.
 
-Policy(eval_mode) is the rl model which we need to check.
+Policy(eval_mode) is the RL model which we need to check.
 
 Evaluator controller is a component to determine if we should stop evaluating or not. For example, in ``Serial
 Evaluator``, ``n_evaluator_episode`` is an argument to determine how many episodes we want to collect and evaluate. Once
@@ -484,7 +484,7 @@ Combined with the evaluation condition(i.e. ``should_eval`` method), We can add 
 .. tip::
    **How to judge whether the model converges or not?**
 
-   We judge whether the model converges or not based on average reward. In DI-engine, there are three types of average
+   We judge whether the model converges or not based on the average reward. In DI-engine, there are three types of average
    reward: winning probability, total cumulative reward and average unit step reward.
 
    Winning probability: In games like ``SMAC``, we focus on the final result and don't care too much about the
@@ -503,14 +503,14 @@ Combined with the evaluation condition(i.e. ``should_eval`` method), We can add 
 
 .. tip::
 
-   **How to solve the problem that different environment in evaluator may collect different length episode?**
+   **How to solve the problem that different environments in evaluator may collect different length episode?**
 
    In some cases, this is really a big problem. For example, suppose we want to collect 12 episodes in evaluator
-   but only have 5 environments, if we didn't do any thing, it is likely that we will get more short episodes than long
+   but only have 5 environments, if we didn't do anything, it is likely that we will get more short episodes than long
    episodes. As a result, our average reward will have a bias and may not be accurate. This is obvious since short
    episodes need less time.
 
-   In order to solve such problem, we use ``VectorEvalMonitor``, a component to balance how many episodes to collect
+   In order to solve the problem, we use ``VectorEvalMonitor``, a component to balance how many episodes to collect
    per environment. Let's go back to the above example, we will collect three episodes for either of the first two
    environments but only two for each of the remaining environments.
 
@@ -522,7 +522,7 @@ Worker-Learner
 ~~~~~~~~~~~~~~~~~~
 Learner is one of the most important components among all the workers, who is responsible for optimizing the policy by training data. Unlike another important component ``Collector``, learner is not divided into serial and parallel modes, i.e. There is only one learner class, serial and parallel entry can call different methods for training.
 
-**Serial pipeline** would call learner's ``train`` method for training. ``train`` method receives a batch of data, and call learn_mode policy's ``_forward_learn`` to train for one iteraton.
+**Serial pipeline** would call learner's ``train`` method for training. ``train`` method receives a batch of data, and call learn_mode policy's ``_forward_learn`` to train for one iteration.
 
 **Parallel pipeline** would call learner's ``start`` method for a complete process of training. ``start`` method has a loop, which includes fetching data from source(Often file system), and calling ``train`` for one-iteration training. ``start`` will train for a specific number of iterations, which is set by use config.
 

--- a/source/quick_start/index.rst
+++ b/source/quick_start/index.rst
@@ -9,7 +9,7 @@ Quick Start
    images/cartpole_cmp.gif
    :align: center
 
-As kickoff, we will illustrate how to launch a RL experiment on a simple ``CartPole`` environment (as shown in above figure) using DI-engine.
+As a kickoff, we will illustrate how to launch an RL experiment on a simple ``CartPole`` environment (as shown in the above figure) using DI-engine.
 
 
 Concretely, we will define a training pipeline in a single python file that specifies the training hyper-parameters, sampling and evaluation environments, the neural networks for the RL agents, as well as the training workflow.
@@ -75,7 +75,7 @@ DI-engine provides default configs for all modules, and also a helper function `
 
 In this example, we only present the procedure to specify config in the entry file. In the following section, we construct the RL pipeline in the same entry file based on the specified config.
 
-Please note that DI-engine also supports running a RL experiment directly according to a given config file, e.g. 
+Please note that DI-engine also supports running an RL experiment directly according to a given config file, e.g. 
 
 .. code:: bash
 
@@ -89,7 +89,7 @@ Initialize the Environments
 
 The RL agents interact with the environment to collect training data or test its performance.
 DI-engine provides enhanced RL environment interfaces derived from the widely used `OpenAI Gym <https://github.com/openai/gym>`_. 
-You can simply wrap the gym environment into DI-engine environment by using the environment warpper :class:`DingEnvWrapper <ding.env.DingEnvWrapper>`.
+You can simply wrap the gym environment into the DI-engine environment by using the environment wrapper :class:`DingEnvWrapper <ding.env.DingEnvWrapper>`.
 You can also construct a more complex environment class following the guidelines in `Environment <../key_concept/index.html#env>`_ section.
 
 The :class:`Env Manager <ding.envs.BaseEnvManager>` is used to manage multiple vectorized environments, usually implemented by
@@ -121,10 +121,10 @@ Set up the Policy and NN models
 -------------------------------
 
 DI-engine supports most of the common policies used in RL training. Each is defined as a :class:`Policy <ding.policy.CommonPolicy>`
-class. The details of optimiaztion algorithm, data pre-processing and post-processing, usage of neural networks
-are encapsulated inside. Users only need to build a PyTorch network structure and pass into the policy. 
+class. The details of optimization algorithms, data pre-processing and post-processing, usage of neural networks
+are encapsulated inside. Users only need to build a PyTorch network structure and pass it into the policy. 
 
-DI-engine also provides default networks to simply apply to the environment. For some complex RL methods, users can imitate the interfaces of these default models and customize own networks.
+DI-engine also provides default networks to simply apply to the environment. For some complex RL methods, users can imitate the interfaces of these default models and customize their own networks.
 
 For example, a ``DQN`` policy for ``CartPole`` can be defined as follow.
 
@@ -141,11 +141,11 @@ DI-engine needs to build some execution components to manage an RL training proc
 A :class:`Collector <ding.worker.collector.SampleCollector>` is used to sample and provide data for training.
 A :class:`Learner <ding.worker.learner.BaseLearner>` is used to receive training data and conduct 
 the training (including updating networks, strategy and etc.).
-An :class:`Evaluator <ding.worker.collector.BaseSerialEvaluator>` is build to perform the evaluation when needed.
+An :class:`Evaluator <ding.worker.collector.BaseSerialEvaluator>` is built to perform the evaluation when needed.
 And other components like :class:`Replay Buffer <ding.worker.replay_buffer.AdvancedReplayBuffer>` may be required for the
-training process. All these module can be customized by config or rewritten by the user.
+training process. All these modules can be customized by config or rewritten by the user.
 
-An example of setting all the above is showed as follow.
+An example of setting all the above is shown as follows.
 
 .. code-block:: python
 
@@ -214,14 +214,14 @@ An easy way of deploying epsilon greedy exploration when sampling data is shown 
         eps = epsilon_greedy(learner.train_iter)
         ...
 
-Firstly, you should call ``get_epsilon_greedy_fn`` to acquire an eps-greedy function. Then, you should call ``epsilon_greedy`` function at each step. The epsilon decay strategy can be configured by you, for example, start value, end value, type of decay(linear, exponential). And you can control whether it decay by env step or train iteration.
+Firstly, you should call ``get_epsilon_greedy_fn`` to acquire an eps-greedy function. Then, you should call ``epsilon_greedy`` function at each step. The epsilon decay strategy can be configured by you, for example, start value, end value, type of decay(linear, exponential). And you can control whether it decays by env steps or train iteration.
 
 
 Visualization & Logging
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Some environments have a rendering visualization. DI-engine doesn't use render interface, but supports saving replay videos instead.
-After training, users can add the code shown below to enable this function. If everything works well, you can find some videos with ``.mp4`` suffix in directory ``replay_path`` (some GUI interfaces are normal).
+After training, users can add the code shown below to enable this function. If everything works well, you can find some videos with the ``.mp4`` suffix in directory ``replay_path`` (some GUI interfaces are normal).
 
 
 .. code-block:: python
@@ -258,7 +258,7 @@ After training, users can add the code shown below to enable this function. If e
 
 
 Similar with other Deep Learning platforms, DI-engine uses tensorboard to record key parameters and results during
-training. In addition to the default logging parameters, users can add their own logging parameters as follow.
+training. In addition to the default logging parameters, users can add their own logging parameters as follows.
 
 .. code-block:: python
 
@@ -271,7 +271,7 @@ DQN experiment.
 Loading & Saving checkpoints
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It is usually needed to save and resume an experiment with model checkpoint. 
+It is usually needed to save and resume an experiment with model checkpoints. 
 DI-engine saves and loads checkpoints in the same way as PyTorch.
 
 .. code-block:: python


### PR DESCRIPTION
fix grammar and typo in the following 5 files:
1. overview
2. installation
3. quick_start
4. key_concept
5. intro_rl