### PR TITLE
fix(hs):fix install atari_env error(en)

### DIFF
--- a/source/env_tutorial/atari.rst
+++ b/source/env_tutorial/atari.rst
@@ -24,6 +24,7 @@ Note：atari-py is now aborted by developer. It is recommended to use `ale-py <h
    # Method1: Install Directly
    pip install gym
    pip install ale-py
+   pip install autorom
    # Method2: Install with DI-engine requirements
    cd DI-engine
    pip install ".[common_env]"


### PR DESCRIPTION
after we install gym0.20.0 and ale-py0.7, we also need to install autorom to successfully verify the installation