### PR TITLE
polish(zjow): rename 'eval reward' -> 'episode return'

### DIFF
--- a/source/01_quickstart/more_rl_program_env.rst
+++ b/source/01_quickstart/more_rl_program_env.rst
@@ -40,7 +40,7 @@ and you can find the whole code implementation and comments `here <https://githu
   - ``WarpFrameWrapper`` : Transform original RGB image to grayscale image and resize it to standard size for DRL training.
   - ``ScaledFloatFrameWrapper`` : Normalize origin image from [0-255] to [0-1], which is beneficial to neural network training.
   - ``FrameStackWrapper`` : Stack the consecutive frames. Due to we can't infer some information like direction speed from a single frame, stacked frames can provide more necessary information.
-  - ``FinalEvalRewardEnv`` : Record final evaluation reward (i.e., episode return in mario), which is adapted to DI-engine's environment format.
+  - ``EvalEpisodeReturnEnv`` : Record final evaluation reward (i.e., episode return in mario), which is adapted to DI-engine's environment format.
 
 
 .. note::
@@ -65,7 +65,7 @@ and you can find the whole code implementation and comments `here <https://githu
                     lambda env: WarpFrameWrapper(env, size=84),
                     lambda env: ScaledFloatFrameWrapper(env),
                     lambda env: FrameStackWrapper(env, n_frames=4),
-                    lambda env: FinalEvalRewardEnv(env),
+                    lambda env: EvalEpisodeReturnEnv(env),
                 ]
             }
         )

--- a/source/01_quickstart/more_rl_program_env.rst
+++ b/source/01_quickstart/more_rl_program_env.rst
@@ -40,7 +40,7 @@ and you can find the whole code implementation and comments `here <https://githu
   - ``WarpFrameWrapper`` : Transform original RGB image to grayscale image and resize it to standard size for DRL training.
   - ``ScaledFloatFrameWrapper`` : Normalize origin image from [0-255] to [0-1], which is beneficial to neural network training.
   - ``FrameStackWrapper`` : Stack the consecutive frames. Due to we can't infer some information like direction speed from a single frame, stacked frames can provide more necessary information.
-  - ``EvalEpisodeReturnEnv`` : Record final evaluation reward (i.e., episode return in mario), which is adapted to DI-engine's environment format.
+  - ``EvalEpisodeReturnEnv`` : Record evaluation episode return (i.e., episode return in mario), which is adapted to DI-engine's environment format.
 
 
 .. note::

--- a/source/01_quickstart/more_rl_program_env_zh.rst
+++ b/source/01_quickstart/more_rl_program_env_zh.rst
@@ -34,7 +34,7 @@ DI-engine 使用全局配置文件来控制环境和策略的所有变量，每�
   - ``WarpFrameWrapper`` : 将原始RGB图像转换为灰度图，并将其调整为标准大小以进行DRL训练。
   - ``ScaledFloatFrameWrapper`` : 将原始图像从[0-255]归一化到[0-1]，有利于神经网络训练。
   - ``FrameStackWrapper`` : 堆叠连续的帧。由于我们无法从单帧推断方向、速度等信息，堆叠帧可以提供更多的必要信息。
-  - ``FinalEvalRewardEnv`` : 记录最终的evaluation reward（即马里奥中的episode return），适配DI-engine的环境格式。
+  - ``EvalEpisodeReturnEnv`` : 记录最终的evaluation reward（即马里奥中的episode return），适配DI-engine的环境格式。
 
 
 .. note::
@@ -60,7 +60,7 @@ DI-engine 使用全局配置文件来控制环境和策略的所有变量，每�
                     lambda env: WarpFrameWrapper(env, size=84),
                     lambda env: ScaledFloatFrameWrapper(env),
                     lambda env: FrameStackWrapper(env, n_frames=4),
-                    lambda env: FinalEvalRewardEnv(env),
+                    lambda env: EvalEpisodeReturnEnv(env),
                 ]
             }
         )

--- a/source/12_policies/rnd.rst
+++ b/source/12_policies/rnd.rst
@@ -250,13 +250,13 @@ Because in collection phase, we use multinomial_sample to increase the diversity
 in evaluation phase, we use the argmax action to interact with env, and we run 5 different seeds and report the mean reward.
 In the experimental results below, the x-axis denotes the total env-steps interacting with the env in the training process.
 In the graph labeled "collector_step", the y-axis shows the rewards received during the collection phase, denoted as collect_reward;
-in the graph labeled "evaluator_step", the y-axis shows the rewards obtained during the evaluation phase, denoted as eval_reward.
+in the graph labeled "evaluator_step", the y-axis shows the rewards obtained during the evaluation phase, denoted as episode_return.
 In the sparse reward envs minigrid, only when the agent reach the goal, the agent will get a positive reward, zero otherwise, and its value will be inversely proportional to the steps used to reach the goal.
 In the easiest env MiniGrid-Empty-8x8-v0, different seeds will have the same room configurations, the optimal reward is about 0.96.
 But in MiniGrid-FourRooms-v0, different seeds will have different room configurations
-and corresponding optimal reward is also different, when the mean of eval_reward is greater than 0.6, we consider the env have been solved.
+and corresponding optimal reward is also different, when the mean of episode_return is greater than 0.6, we consider the env have been solved.
 
--  MiniGrid-Empty-8x8-v0（40k env steps，eval reward_mean>0.95）
+-  MiniGrid-Empty-8x8-v0（40k env steps，episode return_mean>0.95）
 
    - green line is rnd-onppo-weight100
    - red line is onppo
@@ -277,7 +277,7 @@ and corresponding optimal reward is also different, when the mean of eval_reward
      :scale: 50%
 
 
--  MiniGrid-FourRooms-v0（20M env steps，eval reward_mean>0.6）
+-  MiniGrid-FourRooms-v0（20M env steps，episode return_mean>0.6）
 
    - red line is onppo
    - grey line is rnd-onppo-weight1000

--- a/source/13_envs/atari.rst
+++ b/source/13_envs/atari.rst
@@ -144,7 +144,7 @@ Other
 -  ``noop_reset``: When the environment is reset, in the first x original game frames (1 <= x
    <= 30), the player would perform an empty action (i.e. NOOP). This is aimed to increase the randomness of the environment's at the beginning.
 
--  Environment ``step`` method returned ``info`` s must contain ``final_eval_reward`` key-value pair, indicating the entire episode's performance. In Atari, it is the cumulative episode reward.
+-  Environment ``step`` method returned ``info`` s must contain ``eval_episode_return`` key-value pair, indicating the entire episode's performance. In Atari, it is the cumulative episode reward.
 
 
 Other
@@ -191,7 +191,7 @@ After env is initiated, and before it is reset, call ``enable_save_replay`` meth
        action = env.random_action()
        timestep = env.step(action)
        if timestep.done:
-           print('Episode is over, final eval reward is: {}'.format(timestep.info['final_eval_reward']))
+           print('Episode is over, eval episode return is: {}'.format(timestep.info['eval_episode_return']))
            break
 
 DI-zoo Code Example

--- a/source/13_envs/atari_zh.rst
+++ b/source/13_envs/atari_zh.rst
@@ -148,7 +148,7 @@ hub <https://hub.docker.com/r/opendilab/ding>`__\ 获取更多镜像
 
 -  ``noop_reset``\ ：环境重置时，最开始设置 x 个原始游戏帧 ( 1 =< x <=30) 执行空动作（noop），以增加环境开局的随机性
 
--  环境\ ``step``\ 方法返回的\ ``info``\ 必须包含\ ``final_eval_reward``\ 键值对，表示整个 episode 的评测指标，在Atari中为整个episode的奖励累加和
+-  环境\ ``step``\ 方法返回的\ ``info``\ 必须包含\ ``eval_episode_return``\ 键值对，表示整个 episode 的评测指标，在Atari中为整个episode的奖励累加和
 
 
 其他
@@ -195,7 +195,7 @@ hub <https://hub.docker.com/r/opendilab/ding>`__\ 获取更多镜像
        action = env.random_action()
        timestep = env.step(action)
        if timestep.done:
-           print('Episode is over, final eval reward is: {}'.format(timestep.info['final_eval_reward']))
+           print('Episode is over, eval episode return is: {}'.format(timestep.info['eval_episode_return']))
            break
 
 DI-zoo 可运行代码示例

--- a/source/13_envs/bipedalwalker.rst
+++ b/source/13_envs/bipedalwalker.rst
@@ -105,7 +105,7 @@ After the environment is created, but before reset, call the  \ ``enable_save_re
        action = np.random.rand(24)
        timestep = env.step(action)
        if timestep.done:
-           print('Episode is over, final eval reward is: {}'.format(timestep.info['final_eval_reward']))
+           print('Episode is over, eval episode return is: {}'.format(timestep.info['eval_episode_return']))
            break
            
            

--- a/source/13_envs/bipedalwalker_zh.rst
+++ b/source/13_envs/bipedalwalker_zh.rst
@@ -102,7 +102,7 @@ hub <https://hub.docker.com/r/opendilab/ding>`__\
        action = np.random.rand(24)
        timestep = env.step(action)
        if timestep.done:
-           print('Episode is over, final eval reward is: {}'.format(timestep.info['final_eval_reward']))
+           print('Episode is over, eval episode return is: {}'.format(timestep.info['eval_episode_return']))
            break
 
 DI-zoo 可运行代码示例

--- a/source/13_envs/competitive_rl_zh.rst
+++ b/source/13_envs/competitive_rl_zh.rst
@@ -137,8 +137,8 @@ Competitive RL 目前提供两种游戏环境：
 其他
 ----
 
--  如果一个 episode 结束，环境\ ``step``\ 方法返回的\ ``info``\ 必须包含\ ``final_eval_reward``\ 键值对，表示整个 episode 的评测指标，即整个 episode 的奖励累加和
--  和奖励空间相同，只需要传左侧玩家的\ ``final_eval_reward``\
+-  如果一个 episode 结束，环境\ ``step``\ 方法返回的\ ``info``\ 必须包含\ ``eval_episode_return``\ 键值对，表示整个 episode 的评测指标，即整个 episode 的奖励累加和
+-  和奖励空间相同，只需要传左侧玩家的\ ``eval_episode_return``\
 
 
 其他

--- a/source/13_envs/d4rl_zh.rst
+++ b/source/13_envs/d4rl_zh.rst
@@ -218,7 +218,7 @@ Gym-MuJoco 变换前的空间（原始环境）
 其他
 ----
 
--  环境\ ``step``\ 方法返回的\ ``info``\ 必须包含\ ``final_eval_reward``\ 键值对，表示整个episode的评测指标，在 Mujoco 中为整个episode的奖励累加和
+-  环境\ ``step``\ 方法返回的\ ``info``\ 必须包含\ ``eval_episode_return``\ 键值对，表示整个episode的评测指标，在 Mujoco 中为整个episode的奖励累加和
 
 
 其他
@@ -248,7 +248,7 @@ Gym-MuJoco 变换前的空间（原始环境）
        action = env.random_action()
        timestep = env.step(action)
        if timestep.done:
-           print('Episode is over, final eval reward is: {}'.format(timestep.info['final_eval_reward']))
+           print('Episode is over, eval episode return is: {}'.format(timestep.info['eval_episode_return']))
            break
 
 DI-zoo 可运行代码示例

--- a/source/13_envs/dmc2gym.rst
+++ b/source/13_envs/dmc2gym.rst
@@ -256,7 +256,7 @@ After the environment is created, but before reset, call the \ ``enable_save_rep
        action = env.random_action()
        timestep = env.step(action)
        if timestep.done:
-           print('Episode is over, final eval reward is: {}'.format(timestep.info['final_eval_reward']))
+           print('Episode is over, eval episode return is: {}'.format(timestep.info['eval_episode_return']))
            break
 
 

--- a/source/13_envs/dmc2gym_zh.rst
+++ b/source/13_envs/dmc2gym_zh.rst
@@ -253,7 +253,7 @@ dm_control 包含多个domain （即物理模型），而不同domain有不同�
        action = env.random_action()
        timestep = env.step(action)
        if timestep.done:
-           print('Episode is over, final eval reward is: {}'.format(timestep.info['final_eval_reward']))
+           print('Episode is over, eval episode return is: {}'.format(timestep.info['eval_episode_return']))
            break
 
 

--- a/source/13_envs/lunarlander.rst
+++ b/source/13_envs/lunarlander.rst
@@ -124,7 +124,7 @@ The above space can be expressed as:
 Other
 ------------------------
 
-- The \ ``info``\ returned by the environment \ ``step``\ method must contain the \ ``final_eval_reward``\ key-value pair, which represents the evaluation index of the entire episode, and is the cumulative sum of the rewards of the entire episode in lunarlander
+- The \ ``info``\ returned by the environment \ ``step``\ method must contain the \ ``eval_episode_return``\ key-value pair, which represents the evaluation index of the entire episode, and is the cumulative sum of the rewards of the entire episode in lunarlander
 
 Other
 ========
@@ -170,7 +170,7 @@ After the environment is created, but before reset, call the \ ``enable_save_rep
        action = env.random_action()
        timestep = env.step(action)
        if timestep.done:
-           print('Episode is over, final eval reward is: {}'.format(timestep.info['final_eval_reward']))
+           print('Episode is over, eval episode return is: {}'.format(timestep.info['eval_episode_return']))
            break
 
 DI-zoo Runnable Code Example

--- a/source/13_envs/lunarlander_zh.rst
+++ b/source/13_envs/lunarlander_zh.rst
@@ -136,7 +136,7 @@ DI-engine 的镜像配备有框架本身和 Lunarlander 环境，可通过\ ``do
 其他
 ----
 
--  环境\ ``step``\ 方法返回的\ ``info``\ 必须包含\ ``final_eval_reward``\ 键值对，表示整个 episode 的评测指标，在lunarlander 中为整个 episode 的奖励累加和
+-  环境\ ``step``\ 方法返回的\ ``info``\ 必须包含\ ``eval_episode_return``\ 键值对，表示整个 episode 的评测指标，在lunarlander 中为整个 episode 的奖励累加和
 
 
 其他
@@ -183,7 +183,7 @@ DI-engine 的镜像配备有框架本身和 Lunarlander 环境，可通过\ ``do
        action = env.random_action()
        timestep = env.step(action)
        if timestep.done:
-           print('Episode is over, final eval reward is: {}'.format(timestep.info['final_eval_reward']))
+           print('Episode is over, eval episode return is: {}'.format(timestep.info['eval_episode_return']))
            break
 
 DI-zoo 可运行代码示例

--- a/source/13_envs/minigrid.rst
+++ b/source/13_envs/minigrid.rst
@@ -167,7 +167,7 @@ The above space can be expressed as:
 Other
 --------
 
-- The \ ``info``\ returned by the environment \ ``step``\ method must contain the \ ``final_eval_reward``\ key-value pair, which represents the evaluation index of the entire episode, and is the cumulative sum of the rewards of the entire episode in minigrid
+- The \ ``info``\ returned by the environment \ ``step``\ method must contain the \ ``eval_episode_return``\ key-value pair, which represents the evaluation index of the entire episode, and is the cumulative sum of the rewards of the entire episode in minigrid
 
 Other
 ======
@@ -208,7 +208,7 @@ After the environment is created, but before reset, call the \ ``enable_save_rep
       random_action = np.random.randint(min_val, max_val, size=(1,))
       timestep = env.step(random_action)
       if timestep.done:
-          print('Episode is over, final eval reward is: {}'.format(timestep.info['final_eval_reward']))
+          print('Episode is over, eval episode return is: {}'.format(timestep.info['eval_episode_return']))
           break
 
 DI-zoo Runnable Code Example

--- a/source/13_envs/minigrid_zh.rst
+++ b/source/13_envs/minigrid_zh.rst
@@ -178,7 +178,7 @@ MiniGrid-ObstructedMaze-2Dlh-v0, MiniGrid-ObstructedMaze-Full-v0 等一系列环
 其他
 ----
 
--  环境\ ``step``\ 方法返回的\ ``info``\ 必须包含\ ``final_eval_reward``\ 键值对，表示整个 episode 的评测指标，在 minigrid 中为整个 episode 的奖励累加和
+-  环境\ ``step``\ 方法返回的\ ``info``\ 必须包含\ ``eval_episode_return``\ 键值对，表示整个 episode 的评测指标，在 minigrid 中为整个 episode 的奖励累加和
 
 
 其他
@@ -220,7 +220,7 @@ MiniGrid-ObstructedMaze-2Dlh-v0, MiniGrid-ObstructedMaze-Full-v0 等一系列环
       random_action = np.random.randint(min_val, max_val, size=(1,))
       timestep = env.step(random_action)
       if timestep.done:
-          print('Episode is over, final eval reward is: {}'.format(timestep.info['final_eval_reward']))
+          print('Episode is over, eval episode return is: {}'.format(timestep.info['eval_episode_return']))
           break
 
 DI-zoo 可运行代码示例

--- a/source/13_envs/mujoco.rst
+++ b/source/13_envs/mujoco.rst
@@ -172,7 +172,7 @@ The above space can be expressed as:
 Other
 ------
 
-- The \ ``info``\ returned by the environment \ ``step``\ method must contain\ ``final_eval_reward``\ key-value pair, indicating the evaluation index of the entire episode, and the cumulative sum of the rewards of the entire episode in Mujoco
+- The \ ``info``\ returned by the environment \ ``step``\ method must contain\ ``eval_episode_return``\ key-value pair, indicating the evaluation index of the entire episode, and the cumulative sum of the rewards of the entire episode in Mujoco
 
 
 Other
@@ -217,7 +217,7 @@ After the environment is created, but before reset, call the\ ``enable_save_repl
        action = env.random_action()
        timestep = env.step(action)
        if timestep.done:
-           print('Episode is over, final eval reward is: {}'.format(timestep.info['final_eval_reward']))
+           print('Episode is over, eval episode return is: {}'.format(timestep.info['eval_episode_return']))
            break
 
 DI-zoo Runnable Code Example

--- a/source/13_envs/mujoco_zh.rst
+++ b/source/13_envs/mujoco_zh.rst
@@ -183,7 +183,7 @@ hub <https://hub.docker.com/r/opendilab/ding>`_  获取更多镜像
 其他
 ----
 
--  环境\ ``step``\ 方法返回的\ ``info``\ 必须包含\ ``final_eval_reward``\ 键值对，表示整个 episode 的评测指标，在 Mujoco 中为整个 episode 的奖励累加和
+-  环境\ ``step``\ 方法返回的\ ``info``\ 必须包含\ ``eval_episode_return``\ 键值对，表示整个 episode 的评测指标，在 Mujoco 中为整个 episode 的奖励累加和
 
 
 其他
@@ -229,7 +229,7 @@ hub <https://hub.docker.com/r/opendilab/ding>`_  获取更多镜像
        action = env.random_action()
        timestep = env.step(action)
        if timestep.done:
-           print('Episode is over, final eval reward is: {}'.format(timestep.info['final_eval_reward']))
+           print('Episode is over, eval episode return is: {}'.format(timestep.info['eval_episode_return']))
            break
 
 DI-zoo 可运行代码示例

--- a/source/13_envs/multiagent_particle_zh.rst
+++ b/source/13_envs/multiagent_particle_zh.rst
@@ -178,7 +178,7 @@ MPE 已经被集成在 DI-engine/dizoo 仓库中，所以只要安装 DI-engine 
        action = env.random_action()
        timestep = env.step(action)
        if timestep.done:
-           print('Episode is over, final eval reward is: {}'.format(timestep.info['final_eval_reward']))
+           print('Episode is over, eval episode return is: {}'.format(timestep.info['eval_episode_return']))
            break
 
 DI-zoo 代码示例

--- a/source/13_envs/procgen.rst
+++ b/source/13_envs/procgen.rst
@@ -131,7 +131,7 @@ The above space can be expressed as:
 Other
 ------
 
-\ ``info``\returned by the method \ ``step``\ must contain\ ``final_eval_reward``\ key - value pair, representing the evaluation metrics of the entire episode, and the cumulative sum of the rewards for the entire episode in Procgen
+\ ``info``\returned by the method \ ``step``\ must contain\ ``eval_episode_return``\ key - value pair, representing the evaluation metrics of the entire episode, and the cumulative sum of the rewards for the entire episode in Procgen
 
 
 Other
@@ -174,7 +174,7 @@ After the environment is created, but before reset, call the \ ``enable_save_rep
        action = env.random_action()
        timestep = env.step(action)
        if timestep.done:
-           print('Episode is over, final eval reward is: {}'.format(timestep.info['final_eval_reward']))
+           print('Episode is over, eval episode return is: {}'.format(timestep.info['eval_episode_return']))
            break
 
 DI-zoo Runnable Code Example

--- a/source/13_envs/procgen_zh.rst
+++ b/source/13_envs/procgen_zh.rst
@@ -143,7 +143,7 @@ procgen 的全称是 Procedural Generation，表示程序化生成。对于 proc
 其他
 ----
 
--  环境\ ``step``\ 方法返回的\ ``info``\ 必须包含\ ``final_eval_reward``\ 键值对，表示整个 episode 的评测指标，在 Procgen 中为整个 episode 的奖励累加和
+-  环境\ ``step``\ 方法返回的\ ``info``\ 必须包含\ ``eval_episode_return``\ 键值对，表示整个 episode 的评测指标，在 Procgen 中为整个 episode 的奖励累加和
 
 
 其他
@@ -188,7 +188,7 @@ procgen 的全称是 Procedural Generation，表示程序化生成。对于 proc
        action = env.random_action()
        timestep = env.step(action)
        if timestep.done:
-           print('Episode is over, final eval reward is: {}'.format(timestep.info['final_eval_reward']))
+           print('Episode is over, eval episode return is: {}'.format(timestep.info['eval_episode_return']))
            break
 
 DI-zoo 可运行代码示例

--- a/source/13_envs/pybullet_zh.rst
+++ b/source/13_envs/pybullet_zh.rst
@@ -125,7 +125,7 @@ hub <https://hub.docker.com/r/opendilab/ding>`_  获取更多镜像
 其他
 ----
 
--  环境\ ``step``\ 方法返回的\ ``info``\ 必须包含\ ``final_eval_reward``\ 键值对，表示整个 episode 的评测指标，在 Pybullet 中为整个 episode 的奖励累加和
+-  环境\ ``step``\ 方法返回的\ ``info``\ 必须包含\ ``eval_episode_return``\ 键值对，表示整个 episode 的评测指标，在 Pybullet 中为整个 episode 的奖励累加和
 
 
 其他
@@ -171,7 +171,7 @@ hub <https://hub.docker.com/r/opendilab/ding>`_  获取更多镜像
         action = env.random_action()
         timestep = env.step(action)
         if timestep.done:
-            print('Episode is over, final eval reward is: {}'.format(timestep.info['final_eval_reward']))
+            print('Episode is over, eval episode return is: {}'.format(timestep.info['eval_episode_return']))
             break
 
 DI-zoo 可运行代码示例

--- a/source/13_envs/slime_volleyball.rst
+++ b/source/13_envs/slime_volleyball.rst
@@ -144,7 +144,7 @@ Using Slime Volleyball in 'OpenAI Gym' format:
 Other
 ------
 
-- The\ `info``\ returned form the environment\ ``step``\ must contain the\ ``final_eval_reward``\ key-value pair, which represents the evaluation metrics for the entire episode, containing the rewards for the episode (life value difference between two players).
+- The\ `info``\ returned form the environment\ ``step``\ must contain the\ ``eval_episode_return``\ key-value pair, which represents the evaluation metrics for the entire episode, containing the rewards for the episode (life value difference between two players).
 
 - The above spatial definitions are all descriptions of single intelligences. The multi-intelligence space splices the corresponding obs/action/reward information.
 
@@ -194,7 +194,7 @@ After env is initiated, and before it is reset, call ``enable_save_replay`` meth
        action = env.random_action()
        timestep = env.step(action)
        if timestep.done:
-           print('Episode is over, final eval reward is: {}'.format(timestep.info['final_eval_reward']))
+           print('Episode is over, eval episode return is: {}'.format(timestep.info['eval_episode_return']))
            break
 
 DI-zoo runnable code

--- a/source/13_envs/slime_volleyball_zh.rst
+++ b/source/13_envs/slime_volleyball_zh.rst
@@ -146,7 +146,7 @@ hub <https://hub.docker.com/r/opendilab/ding>`__\ 获取更多镜像
 其他
 ----
 
--  环境\ ``step``\ 方法返回的\ ``info``\ 必须包含\ ``final_eval_reward``\ 键值对，表示整个 episode 的评测指标，在这里为整个 episode 的奖励累加和（即我方相比对手的生命值差异）
+-  环境\ ``step``\ 方法返回的\ ``info``\ 必须包含\ ``eval_episode_return``\ 键值对，表示整个 episode 的评测指标，在这里为整个 episode 的奖励累加和（即我方相比对手的生命值差异）
 -  如果选择智能体对战内置 bot，请将环境输入配置的 ``agent_vs_agent`` 字段设置为 False，智能体对战智能体则设置为 True
 -  上述空间定义均是对单智能体的说明（即智能体对战内置 bot），多智能体的空间是将上述 obs/action/reward 进行对应拼接等操作，例如观察空间由 ``(12, )`` 变为 ``(2, 12)``，代表双方的观察信息
 
@@ -193,7 +193,7 @@ hub <https://hub.docker.com/r/opendilab/ding>`__\ 获取更多镜像
        action = env.random_action()
        timestep = env.step(action)
        if timestep.done:
-           print('Episode is over, final eval reward is: {}'.format(timestep.info['final_eval_reward']))
+           print('Episode is over, eval episode return is: {}'.format(timestep.info['eval_episode_return']))
            break
 
 DI-zoo可运行代码示例

--- a/source/13_envs/smac.rst
+++ b/source/13_envs/smac.rst
@@ -134,7 +134,7 @@ Other
 
 - Turn on \ ``special_global_state``\ and turn on \ ``death_mask``\, if an agent dies, the returned global_state only contains its own ID information, and all other information is masked
 
-- The \ ``info``\ returned by the environment \ ``step``\ method must contain the \ ``final_eval_reward``\ key-value pair, which represents the evaluation index of the entire episode, and is the cumulative sum of the fake_reward of the entire episode in SMAC
+- The \ ``info``\ returned by the environment \ ``step``\ method must contain the \ ``eval_episode_return``\ key-value pair, which represents the evaluation index of the entire episode, and is the cumulative sum of the fake_reward of the entire episode in SMAC
 
 - The final \ ``reward``\ returned by the environment \ ``step``\ method is victory or not
 
@@ -206,20 +206,20 @@ Use the method provided by \`<https://github.com/opendilab/DI-engine/blob/main/d
         policy.load_state_dict(state_dict)
 
         obs = env.reset()
-        eval_reward = 0.
+        episode_return = 0.
         while True:
             policy_output = policy.forward({0:obs})
             action = policy_output[0]['action']
             print(action)
             timestep = env.step(action)
-            eval_reward += timestep.reward
+            episode_return += timestep.reward
             obs = timestep.obs
             if timestep.done:
                 print(timestep.info)
                 break
 
         env.save_replay(replay_dir='.', prefix=env._map_name)
-        print('Eval is over! The performance of your RL policy is {}'.format(eval_reward))
+        print('Eval is over! The performance of your RL policy is {}'.format(episode_return))
 
 
     if __name__ == "__main__":

--- a/source/13_envs/smac_zh.rst
+++ b/source/13_envs/smac_zh.rst
@@ -134,7 +134,7 @@ hub <https://hub.docker.com/r/opendilab/ding>`__\ 获取更多镜像
 
 -  开启\ ``special_global_state``\ 且开启\ ``death_mask``\，则若一个agent阵亡，则其返回的 global_state 仅包含其自身的 ID 信息，其余信息全部被屏蔽
 
--  环境\ ``step``\ 方法返回的\ ``info``\ 必须包含\ ``final_eval_reward``\ 键值对，表示整个 episode 的评测指标，在 SMAC 中为整个 episode 的 fake_reward 累加和
+-  环境\ ``step``\ 方法返回的\ ``info``\ 必须包含\ ``eval_episode_return``\ 键值对，表示整个 episode 的评测指标，在 SMAC 中为整个 episode 的 fake_reward 累加和
 
 -  环境\ ``step``\ 方法最终返回的\ ``reward``\ 为胜利与否
 
@@ -206,20 +206,20 @@ hub <https://hub.docker.com/r/opendilab/ding>`__\ 获取更多镜像
         policy.load_state_dict(state_dict)
 
         obs = env.reset()
-        eval_reward = 0.
+        episode_return = 0.
         while True:
             policy_output = policy.forward({0: obs})
             action = policy_output[0]['action']
             print(action)
             timestep = env.step(action)
-            eval_reward += timestep.reward
+            episode_return += timestep.reward
             obs = timestep.obs
             if timestep.done:
                 print(timestep.info)
                 break
 
         env.save_replay(replay_dir='.', prefix=env._map_name)
-        print('Eval is over! The performance of your RL policy is {}'.format(eval_reward))
+        print('Eval is over! The performance of your RL policy is {}'.format(episode_return))
 
 
     if __name__ == "__main__":

--- a/source/13_envs/sokoban.rst
+++ b/source/13_envs/sokoban.rst
@@ -160,5 +160,5 @@ After the environment is created, but before reset, call the \ ``enable_save_rep
       action = env.action_space.sample()
       timestep = env.step(action)
       if timestep.done:
-          print('Episode is over, final eval reward is: {}'.format(timestep.info['final_eval_reward']))
+          print('Episode is over, eval episode return is: {}'.format(timestep.info['eval_episode_return']))
           break

--- a/source/13_envs/sokoban_zh.rst
+++ b/source/13_envs/sokoban_zh.rst
@@ -156,5 +156,5 @@ Sokoban 是一种离散动作空间环境。在该游戏中，智能体需要在
       action = env.action_space.sample()
       timestep = env.step(action)
       if timestep.done:
-          print('Episode is over, final eval reward is: {}'.format(timestep.info['final_eval_reward']))
+          print('Episode is over, eval episode return is: {}'.format(timestep.info['eval_episode_return']))
           break


### PR DESCRIPTION
fix typo 'eval reward' -> 'episode return'
fix typo 'eval_reward' -> 'episode_return'
fix typo 'EvalReward' -> 'EpisodeReturn'
fix typo 'final eval reward' -> 'eval episode return'
fix typo 'final_eval_reward' -> 'eval_episode_return'
fix typo 'FinalEvalReward' -> 'EvalEpisodeReturn'